### PR TITLE
Escape values when necessary

### DIFF
--- a/lib/puppet-catalog_rspec/resource.rb
+++ b/lib/puppet-catalog_rspec/resource.rb
@@ -30,7 +30,12 @@ class Puppet::Resource
       when :subscribe
         [v].flatten.each { |r| puts "  .that_subscribes_to('#{v}')" }
       else
-        puts "  .with(#{("'#{k}'").ljust(max_length + 2)} => '#{v}')"
+        val = if v.is_a?(String) && (v.match?(%r{'}) || v.dump[1..-2] != v)
+                v.dump
+              else
+                "'#{v}'"
+              end
+        puts "  .with(#{("'#{k}'").ljust(max_length + 2)} => #{val})"
       end
     end
   end


### PR DESCRIPTION
This PR allows values containing single quotes to be escaped correctly. Prior to this change, given an example manifest
```puppet
class test {
  file { '/test_file':
    content => "This isn't escaped",
  }
}
```
dump_catalog wouldn't escape the single quote, producing an invalid code snippet:
```ruby
it { is_expected.to contain_file('/test_file')
  .with('path'    => '/test_file')
  .with('content' => 'This isn't escaped')
}
```
With this change, only values that need escaping are escaped, leaving single quotes in other cases:
```ruby
it { is_expected.to contain_file('/test_file')
  .with('path'    => '/test_file')
  .with('content' => "This isn't escaped")
}
```