### PR TITLE
output improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,25 +48,31 @@ it { dump_catalog }
 This will dump the full current catalog as rspec-code. Here is an example:
 
 ```
-it { is_expected.to contain_archive('/install/p17572726_1036_Generic.zip')
-  .with('path'    => '/install/p17572726_1036_Generic.zip')
-  .with('ensure'  => 'present')
-  .with('cleanup' => 'false')
-  .with('extract' => 'false')
-  .with('source'  => 'puppet:///middleware/p17572726_1036_Generic.zip')
-  .with('user'    => 'oracle')
-  .with('group'   => 'dba')
-  .that_requires('File[/opt/oracle/middleware/utils/bsu/cache_dir]')
+it {
+  is_expected.to contain_archive('/install/p17572726_1036_Generic.zip')
+    .that_requires('File[/opt/oracle/middleware/utils/bsu/cache_dir]')
+    .with(
+      path:    '/install/p17572726_1036_Generic.zip',
+      ensure:  'present',
+      cleanup: 'false',
+      extract: 'false',
+      source:  'puppet:///middleware/p17572726_1036_Generic.zip',
+      user:    'oracle',
+      group:   'dba',
+    )
 }
 
-it { is_expected.to contain_exec('patch policy for p17572726_1036_Generic.zip')
-  .with('command'   => 'bash -c "{ echo 'grant codeBase \"file:/opt/oracle/middleware/patch_wls1036/patch_jars/-\" {'; echo '      permission java.security.AllPermission;'; echo '};'; } >> /opt/oracle/middleware/wlserver/server/lib/weblogic.policy"')
-  .with('unless'    => 'grep 'file:/opt/oracle/middleware/patch_wls1036/patch_jars/-' /opt/oracle/middleware/wlserver/server/lib/weblogic.policy')
-  .with('path'      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/java/jdk1.7.0_45/bin')
-  .with('user'      => 'oracle')
-  .with('group'     => 'dba')
-  .with('logoutput' => 'on_failure')
-  .that_requires('Bsu_patch[FCX7]')
+it {
+  is_expected.to contain_exec('patch policy for p17572726_1036_Generic.zip')
+    .that_requires('Bsu_patch[FCX7]')
+    .with(
+      command:   "bash -c \"{ echo 'grant codeBase \\\"file:/opt/oracle/middleware/patch_wls1036/patch_jars/-\\\" {'; echo '      permission java.security.AllPermission;'; echo '};'; } >> /opt/oracle/middleware/wlserver/server/lib/weblogic.policy\"",
+      unless:    "grep 'file:/opt/oracle/middleware/patch_wls1036/patch_jars/-' /opt/oracle/middleware/wlserver/server/lib/weblogic.policy",
+      path:      '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/java/jdk1.7.0_45/bin',
+      user:      'oracle',
+      group:     'dba',
+      logoutput' 'on_failure',
+    )
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There is no one single workflow that works, but this is what we use. In your spe
 it { dump_catalog }
 ```
 
-This will dump the full current catalog as rspec-code. Here is an example:
+This will dump the full current catalog as rspec-code to standard output. Here is an example:
 
 ```
 it {
@@ -75,6 +75,13 @@ it {
     )
 }
 ```
+
+Alternatively, instead of dumping to standard output, use the following to save the generated rspec:
+
+```
+it { rspec_catalog('generated_rspec_catalog.rb') }
+```
+
 
 Now copy and paste the parts that you want to check in your manifest into your rspec-code and voila.
 ## Development

--- a/lib/puppet-catalog_rspec/resource.rb
+++ b/lib/puppet-catalog_rspec/resource.rb
@@ -2,36 +2,64 @@ require 'puppet/resource'
 
 # Monky patch Puppet
 class Puppet::Resource
+  @@rspec_that = {
+    require: 'requires',
+    before: 'comes_before',
+    notify: 'notifies',
+    subscribe: 'subscribes_to',
+  }
+
   def to_rspec
     type = self.type.downcase.tr(':', '_')
-    puts "it { is_expected.to contain_#{type}('#{title}')"
-    properties
-    puts '}'
+    props = rspec_properties
+
+    if props[:that].empty? && props[:with].empty?
+      puts "it { is_expected.to contain_#{type}('#{title}') }"
+    else
+      puts "it {"
+      puts "  is_expected.to contain_#{type}('#{title}')"
+      puts props[:that].join("\n") unless props[:that].empty?
+      if props[:with].size.eql?(1)
+        puts "    .with(#{props[:with][0]})"
+      elsif !props[:with].empty?
+        puts "    .with("
+        props[:with].each { |prop| puts "      #{prop}," }
+        puts "    )"
+      end
+      puts '}'
+    end
     puts ''
   end
 
   private
 
-  def properties
+  def rspec_value(v)
+    if v.is_a?(String)
+      (v.dump[1..-2] != v) ? v.dump : "'#{v}'"
+    else
+      v.inspect
+    end
+  end
+
+  def rspec_properties
+    props = {
+      that: [],
+      with: [],
+    }
     hash = to_hash
     keys = hash.keys
     max_length = keys.map(&:length).max
+
     hash.each do |k, v|
-      case k
-      when :name
-        # Skip name
-        next
-      when :require
-        [v].flatten.each { |r| puts "  .that_requires('#{r}')" }
-      when :before
-        [v].flatten.each { |r| puts "  .that_comes_before('#{r}')" }
-      when :notify
-        [v].flatten.each { |r| puts "  .that_notifies('#{r}')" }
-      when :subscribe
-        [v].flatten.each { |r| puts "  .that_subscribes_to('#{v}')" }
+      next if k.eql?(:name)
+
+      if @@rspec_that[k]
+        [v].flatten.each { |r| props[:that] << "    .that_#{@@rspec_that[k]}('#{r}')" }
       else
-        puts "  .with(#{("'#{k}'").ljust(max_length + 2)} => '#{v}')"
+        props[:with] << "#{(k.to_s + ':').ljust(max_length + 1)} #{rspec_value(v)}"
       end
     end
+
+    props
   end
 end

--- a/lib/puppet-catalog_rspec/rspec.rb
+++ b/lib/puppet-catalog_rspec/rspec.rb
@@ -1,3 +1,17 @@
 def dump_catalog
   catalogue.to_rspec
 end
+
+def rspec_catalog(output = nil)
+  o_stdout = $stdout
+  if output
+    $stdout = File.open(output, 'w+')
+  else
+    $stdout = StringIO.new
+  end
+  catalogue.to_rspec
+  yield
+  $stdout.string
+ensure
+  $stdout = o_stdout
+end


### PR DESCRIPTION
* inspect all property value types except String
* single quote property strings if it doesn't need to be escaped, otherwise inspect
* use symbols for with keys
* improve output formatting

Old:
```
it { is_expected.to contain_class('Apt')
  .with('update_defaults'     => '{"frequency"=>"reluctantly", "loglevel"=>nil, "timeout"=>nil, "tries"=>nil}')
  .with('purge_defaults'      => '{"sources.list"=>false, "sources.list.d"=>false, "preferences"=>false, "preferences.d"=>false, "apt.conf.d"=>false}')
  .with('proxy_defaults'      => '{"ensure"=>nil, "host"=>nil, "port"=>8080, "https"=>false, "https_acng"=>false, "direct"=>false}')
  .with('include_defaults'    => '{"deb"=>true, "src"=>false}')
  .with('provider'            => '/usr/bin/apt-get')
  .with('keyserver'           => 'keyserver.ubuntu.com')
  .with('ppa_options'         => '["-y"]')
  .with('ppa_package'         => 'software-properties-common')
  .with('backports'           => '{"location"=>"http://archive.ubuntu.com/ubuntu", "repos"=>"main universe multiverse restricted"}')
  .with('confs'               => '{}')
  .with('update'              => '{}')
  .with('purge'               => '{}')
  .with('proxy'               => '{}')
  .with('sources'             => '{}')
  .with('keys'                => '{}')
  .with('keyrings'            => '{}')
  .with('ppas'                => '{}')
  .with('pins'                => '{}')
  .with('settings'            => '{}')
  .with('manage_auth_conf'    => 'true')
  .with('auth_conf_entries'   => '[]')
  .with('auth_conf_owner'     => '_apt')
  .with('root'                => '/etc/apt')
  .with('sources_list'        => '/etc/apt/sources.list')
  .with('sources_list_d'      => '/etc/apt/sources.list.d')
  .with('conf_d'              => '/etc/apt/apt.conf.d')
  .with('preferences'         => '/etc/apt/preferences')
  .with('preferences_d'       => '/etc/apt/preferences.d')
  .with('apt_conf_d'          => '/etc/apt/apt.conf.d')
  .with('config_files'        => '{"conf"=>{"path"=>"/etc/apt/apt.conf.d", "ext"=>""}, "pref"=>{"path"=>"/etc/apt/preferences.d", "ext"=>".pref"}, "list"=>{"path"=>"/etc/apt/sources.list.d", "ext"=>".list"}}')
  .with('sources_list_force'  => 'false')
  .with('source_key_defaults' => '{"server"=>"keyserver.ubuntu.com", "options"=>nil, "content"=>nil, "source"=>nil}')
}

it { is_expected.to contain_class('Apt::Update')
}

it { is_expected.to contain_apt__setting('conf-update-stamp')
  .with('priority'      => '15')
  .with('content'       => '// This file is managed by Puppet. DO NOT EDIT.
APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true";};
')
  .with('ensure'        => 'file')
  .with('notify_update' => 'true')
}
```

New:
```
it {
  is_expected.to contain_class('Apt')
    .with(
      update_defaults:     {"frequency"=>"reluctantly", "loglevel"=>nil, "timeout"=>nil, "tries"=>nil},
      purge_defaults:      {"sources.list"=>false, "sources.list.d"=>false, "preferences"=>false, "preferences.d"=>false, "apt.conf.d"=>false},
      proxy_defaults:      {"ensure"=>nil, "host"=>nil, "port"=>8080, "https"=>false, "https_acng"=>false, "direct"=>false},
      include_defaults:    {"deb"=>true, "src"=>false},
      provider:            '/usr/bin/apt-get',
      keyserver:           'keyserver.ubuntu.com',
      ppa_options:         ["-y"],
      ppa_package:         'software-properties-common',
      backports:           {"location"=>"http://archive.ubuntu.com/ubuntu", "repos"=>"main universe multiverse restricted"},
      confs:               {},
      update:              {},
      purge:               {},
      proxy:               {},
      sources:             {},
      keys:                {},
      keyrings:            {},
      ppas:                {},
      pins:                {},
      settings:            {},
      manage_auth_conf:    true,
      auth_conf_entries:   [],
      auth_conf_owner:     '_apt',
      root:                '/etc/apt',
      sources_list:        '/etc/apt/sources.list',
      sources_list_d:      '/etc/apt/sources.list.d',
      conf_d:              '/etc/apt/apt.conf.d',
      preferences:         '/etc/apt/preferences',
      preferences_d:       '/etc/apt/preferences.d',
      apt_conf_d:          '/etc/apt/apt.conf.d',
      config_files:        {"conf"=>{"path"=>"/etc/apt/apt.conf.d", "ext"=>""}, "pref"=>{"path"=>"/etc/apt/preferences.d", "ext"=>".pref"}, "list"=>{"path"=>"/etc/apt/sources.list.d", "ext"=>".list"}},
      sources_list_force:  false,
      source_key_defaults: {"server"=>"keyserver.ubuntu.com", "options"=>nil, "content"=>nil, "source"=>nil},
}

it { is_expected.to contain_class('Apt::Update') }

it {
  is_expected.to contain_apt__setting('conf-update-stamp')
    .with(
      priority:      15,
      content:       "// This file is managed by Puppet. DO NOT EDIT.\nAPT::Update::Post-Invoke-Success {\"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true\";};\n",
      ensure:        'file',
      notify_update: true,
}
```